### PR TITLE
feat: update AI SDK response types and enhance request mapping

### DIFF
--- a/packages/router/src/modules/chat-completions/handle-ai-sdk-stream-response.ts
+++ b/packages/router/src/modules/chat-completions/handle-ai-sdk-stream-response.ts
@@ -4,7 +4,7 @@ import type { Response } from 'express';
 export async function handleAiSdkStreamResponse(
   model: string,
   expressResponse: Response,
-  aiResponse: StreamTextResult<never, never>
+  aiResponse: StreamTextResult<{}, unknown>
 ) {
   const { textStream, response: responsePromise } = aiResponse;
 

--- a/packages/router/src/modules/chat-completions/handle-ai-sdk-text-response.ts
+++ b/packages/router/src/modules/chat-completions/handle-ai-sdk-text-response.ts
@@ -5,7 +5,7 @@ import type { OpenAIChatCompletionResponse } from './types/openai.js';
 export function handleAiSdkTextResponse(
   model: string,
   expressResponse: Response,
-  aiResponse: GenerateTextResult<never, never>
+  aiResponse: GenerateTextResult<{}, unknown>
 ) {
   // Transform the response to match OpenAI's format
   const openAIResponse: OpenAIChatCompletionResponse = {

--- a/packages/router/src/modules/chat-completions/routes/chat-completion.ts
+++ b/packages/router/src/modules/chat-completions/routes/chat-completion.ts
@@ -83,6 +83,7 @@ export const handler: RequestHandler<
         case 'openai': {
           const aiResponse = openAICreateStreamingChatCompletion(
             transformedRequest,
+            provider.baseURL,
             provider.apiKey
           );
 
@@ -150,6 +151,7 @@ export const handler: RequestHandler<
         case 'openai': {
           const response = await openAICreateChatCompletion(
             transformedRequest,
+            provider.baseURL,
             provider.apiKey
           );
 

--- a/packages/router/src/modules/llm-providers/google/proxy.ts
+++ b/packages/router/src/modules/llm-providers/google/proxy.ts
@@ -3,6 +3,7 @@ import type { OpenAIChatCompletionRequest } from '../../chat-completions/types/o
 
 import type { GenerateTextResult } from 'ai';
 import { generateText, streamText } from 'ai';
+import { openAiToAiSdkRequestMapper } from '../utils/openai-to-ai-sdk-request-mapper.js';
 
 type GoogleProviderConfig = {
   apiKey: string;
@@ -11,12 +12,16 @@ type GoogleProviderConfig = {
 export async function createChatCompletion(
   request: OpenAIChatCompletionRequest,
   config: GoogleProviderConfig
-): Promise<GenerateTextResult<never, never>> {
+): Promise<GenerateTextResult<{}, unknown>> {
   try {
     const google = createGoogleGenerativeAI({ apiKey: config.apiKey });
     const model = google(request.model);
 
-    return await generateText({ model, messages: request.messages });
+    return await generateText({
+      model,
+      messages: request.messages,
+      ...openAiToAiSdkRequestMapper(request),
+    });
   } catch (error) {
     throw new Error(
       `Google AI completion failed: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -35,6 +40,7 @@ export function createStreamingChatCompletion(
     return streamText({
       model,
       messages: request.messages,
+      ...openAiToAiSdkRequestMapper(request),
     });
   } catch (error) {
     throw new Error(

--- a/packages/router/src/modules/llm-providers/open-ai/proxy.ts
+++ b/packages/router/src/modules/llm-providers/open-ai/proxy.ts
@@ -2,14 +2,13 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { GenerateTextResult, StreamTextResult } from 'ai';
 import { generateText, streamText } from 'ai';
 import type { OpenAIChatCompletionRequest } from '../../chat-completions/types/openai.js';
-
-// TODO: Make this configurable
-const ENDPOINT = 'https://openrouter.ai/api/v1';
+import { openAiToAiSdkRequestMapper } from '../utils/openai-to-ai-sdk-request-mapper.js';
 
 export async function createChatCompletion(
   request: OpenAIChatCompletionRequest,
+  baseURL: string,
   apiKey: string
-): Promise<GenerateTextResult<never, never>> {
+): Promise<GenerateTextResult<{}, unknown>> {
   if (!apiKey) {
     throw new Error('OpenAI API key is required');
   }
@@ -17,11 +16,12 @@ export async function createChatCompletion(
   try {
     const response = await generateText({
       model: createOpenAICompatible({
-        baseURL: ENDPOINT,
-        name: 'Ollama',
+        baseURL,
+        name: 'OpenAI Compatible',
         apiKey,
       }).chatModel(request.model),
       messages: request.messages,
+      ...openAiToAiSdkRequestMapper(request),
     });
 
     return response;
@@ -35,8 +35,9 @@ export async function createChatCompletion(
 
 export function createStreamingChatCompletion(
   request: OpenAIChatCompletionRequest,
+  baseURL: string,
   apiKey: string
-): StreamTextResult<never, never> {
+): StreamTextResult<{}, unknown> {
   if (!apiKey) {
     throw new Error('OpenAI API key is required');
   }
@@ -44,11 +45,12 @@ export function createStreamingChatCompletion(
   try {
     const response = streamText({
       model: createOpenAICompatible({
-        baseURL: ENDPOINT,
-        name: 'Ollama',
+        baseURL,
+        name: 'OpenAI Compatible',
         apiKey,
       }).chatModel(request.model),
       messages: request.messages,
+      ...openAiToAiSdkRequestMapper(request),
     });
 
     return response;

--- a/packages/router/src/modules/llm-providers/utils/openai-to-ai-sdk-request-mapper.ts
+++ b/packages/router/src/modules/llm-providers/utils/openai-to-ai-sdk-request-mapper.ts
@@ -1,0 +1,41 @@
+import { generateText, streamText } from 'ai';
+import { OpenAIChatCompletionRequest } from '../../chat-completions/types/openai.js';
+
+export function openAiToAiSdkRequestMapper(
+  request: OpenAIChatCompletionRequest
+):
+  | Partial<Parameters<typeof generateText>[0]>
+  | Partial<Parameters<typeof streamText>[0]> {
+  // biome-ignore lint/suspicious/noExplicitAny: It's hard to have the correct type here
+  const mappedParams: Record<string, any> = {};
+
+  if (request.temperature !== undefined) {
+    mappedParams['temperature'] = request.temperature;
+  }
+  if (request.max_tokens !== undefined) {
+    mappedParams['maxTokens'] = request.max_tokens;
+  }
+  if (request.top_p !== undefined) {
+    mappedParams['topP'] = request.top_p;
+  }
+  if (request.stop !== undefined) {
+    mappedParams['stop'] = request.stop;
+  }
+  if (request.presence_penalty !== undefined) {
+    mappedParams['presencePenalty'] = request.presence_penalty;
+  }
+  if (request.frequency_penalty !== undefined) {
+    mappedParams['frequencyPenalty'] = request.frequency_penalty;
+  }
+  if (request.logit_bias !== undefined) {
+    mappedParams['responseFormat'] = request.logit_bias;
+  }
+  if (request.stop !== undefined) {
+    mappedParams['stop'] = request.stop;
+  }
+  if (request.user !== undefined) {
+    mappedParams['user'] = request.user;
+  }
+
+  return mappedParams;
+}

--- a/packages/router/tests/http/api/v1/chat/completions.http
+++ b/packages/router/tests/http/api/v1/chat/completions.http
@@ -1,12 +1,29 @@
 # Non-streaming request
+POST http://localhost:3000/api/v1/static-echo/chat/completions
+Content-Type: application/json
+Authorization: Bearer sk-gn1-45EZGuRgQj1Bd6bakeQMYF-2b9a560589deb36838aebe9c1cdf67a60c558ff4eb7ca0de26163b3ca43067cf
 
-POST http://localhost:3000/api/v1/chat/completions
+{
+  "model": "demo-echo",
+  "stream": false,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, how are you?"
+    }
+  ]
+}
+
+
+### Streaming request
+POST http://localhost:3000/api/v1/static-echo/chat/completions
 Content-Type: application/json
 Authorization: Bearer sk-gn1-45EZGuRgQj1Bd6bakeQMYF-2b9a560589deb36838aebe9c1cdf67a60c558ff4eb7ca0de26163b3ca43067cf
 
 {
   "model": "demo-echo",
   "stream": true,
+  "temperature": 0.5,
   "messages": [
     {
       "role": "user",


### PR DESCRIPTION
- Changed response types in handleAiSdkStreamResponse and handleAiSdkTextResponse to use more specific generics.
- Updated createChatCompletion and createStreamingChatCompletion functions in OpenAI and Google providers to reflect new response types.
- Introduced openAiToAiSdkRequestMapper utility to map OpenAI request parameters to the AI SDK format.