### PR TITLE
refactor: rename Flow type and entity to WeaveFlow

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
-pnpm lint-staged
+# Lint everything for now, as the lint-staged command does not get the monorepo setup.
+pnpm lint

--- a/packages/database/src/entities.ts
+++ b/packages/database/src/entities.ts
@@ -92,8 +92,8 @@ export const NextAuthUser: EntityDefinition = {
   },
 };
 
-export const Flow: Collection = {
-  name: 'flow',
+export const WeaveFlow: Collection = {
+  name: 'weaveflow',
   relations: [],
   template: {},
   filterSortFields: {

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -2,7 +2,7 @@ import type { Repository } from 'supersave';
 import {
   ApiKey,
   Deployment,
-  Flow,
+  WeaveFlow,
   NextAuthUser,
   Provider,
   Tenant,
@@ -11,7 +11,7 @@ import { getDB } from './initialize.js';
 import type {
   ApiKey as ApiKeyType,
   Deployment as DeploymentType,
-  Flow as FlowType,
+  WeaveFlow as FlowType,
   NextAuthUser as NextAuthUserType,
   Provider as ProviderType,
   Tenant as TenantType,
@@ -54,7 +54,7 @@ export async function getNextAuthUserRepository(): Promise<
   );
 }
 
-export async function getFlowRepository() {
+export async function getWeaveFlowRepository() {
   const db = await getDB();
-  return db.getRepository<FlowType>(Flow.name);
+  return db.getRepository<FlowType>(WeaveFlow.name);
 }

--- a/packages/database/src/initialize.ts
+++ b/packages/database/src/initialize.ts
@@ -4,7 +4,7 @@ import { SuperSave } from 'supersave';
 import {
   ApiKey,
   Deployment,
-  Flow,
+  WeaveFlow,
   Migration,
   NextAuthUser,
   Provider,
@@ -46,7 +46,7 @@ export async function initialize({
   await db.addCollection(addHooksToCollection(Deployment, hooks));
   await db.addCollection(addHooksToCollection(ApiKey, hooks));
   await db.addCollection(addHooksToCollection(Tenant, hooks));
-  await db.addCollection(addHooksToCollection(Flow, hooks));
+  await db.addCollection(addHooksToCollection(WeaveFlow, hooks));
 
   await db.addCollection(addHooksToCollection(Migration, hooks));
 

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -21,7 +21,7 @@ export function isDeploymentLLM(
 export type ApiKey = dbTypes.ApiKey;
 
 export type Tenant = dbTypes.Tenant;
-export type Flow = dbTypes.Flow;
+export type WeaveFlow = dbTypes.WeaveFlow;
 
 export interface Migration extends BaseEntity {
   version: string;

--- a/packages/management/src/app/app/deployments/[id]/flow/_page.tsx
+++ b/packages/management/src/app/app/deployments/[id]/flow/_page.tsx
@@ -1,10 +1,15 @@
-'use client';
+"use client";
 
-import type { DeploymentApi, Event, Flow, FlowStep } from '@genie-nexus/types';
-import { useCudApi } from '@lib/api/use-api';
-import { ErrorNotification } from '@lib/components/atoms/error-notification';
-import { EmptyFlowState } from '@lib/components/molecules/empty-flow-state';
-import { PipelineBlocksForm } from '@lib/components/molecules/pipeline-blocks-form';
+import type {
+  DeploymentApi,
+  WeaveEvent,
+  WeaveFlow,
+  WeaveFlowStep,
+} from "@genie-nexus/types";
+import { useCudApi } from "@lib/api/use-api";
+import { ErrorNotification } from "@lib/components/atoms/error-notification";
+import { EmptyFlowState } from "@lib/components/molecules/empty-flow-state";
+import { PipelineBlocksForm } from "@lib/components/molecules/pipeline-blocks-form";
 import {
   Button,
   Grid,
@@ -17,8 +22,8 @@ import {
   Text,
   TextInput,
   Title,
-} from '@mantine/core';
-import { useForm } from '@mantine/form';
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
 import {
   IconAlertCircle,
   IconArrowLeft,
@@ -29,18 +34,18 @@ import {
   IconFilter,
   IconListDetails,
   IconTransform,
-} from '@tabler/icons-react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+} from "@tabler/icons-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 
 type Properties = {
   deployment: DeploymentApi;
-  flow: Flow;
+  flow: WeaveFlow;
 };
 
 type FormValues = {
-  events: Event[];
+  events: WeaveEvent[];
 };
 
 export function FlowEditorClientPage({
@@ -48,7 +53,7 @@ export function FlowEditorClientPage({
   deployment,
 }: Properties) {
   const router = useRouter();
-  const [flow, setFlow] = useState<Flow>(originalFlow);
+  const [flow, setFlow] = useState<WeaveFlow>(originalFlow);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [pendingNavigation, setPendingNavigation] = useState<string | null>(
     null
@@ -74,7 +79,7 @@ export function FlowEditorClientPage({
 
     const handleClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
-      const link = target.closest('a');
+      const link = target.closest("a");
       if (link && link.href && !link.href.includes(window.location.pathname)) {
         if (hasUnsavedChanges) {
           e.preventDefault();
@@ -85,12 +90,12 @@ export function FlowEditorClientPage({
       }
     };
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    window.addEventListener('click', handleClick, true);
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener("click", handleClick, true);
 
     return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      window.removeEventListener('click', handleClick, true);
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("click", handleClick, true);
     };
   }, [hasUnsavedChanges]);
 
@@ -110,8 +115,8 @@ export function FlowEditorClientPage({
   };
 
   const handleSave = useCallback(async () => {
-    const updatedFlow = await patch<{ data: Flow }>(
-      `/collections/flows/${flow.id}`,
+    const updatedFlow = await patch<{ data: WeaveFlow }>(
+      `/collections/weaveflows/${flow.id}`,
       {
         ...flow,
         events: form.values.events,
@@ -128,45 +133,48 @@ export function FlowEditorClientPage({
   const [selectedBlockType, setSelectedBlockType] = useState<string | null>(
     null
   );
-  const [modalStep, setModalStep] = useState<'block' | 'pipeline'>('block');
+  const [modalStep, setModalStep] = useState<"block" | "pipeline">("block");
 
   // Building block definitions
   const buildingBlocks = [
-    { label: 'Transform Data', icon: IconTransform, type: 'transform' },
-    { label: 'Validate', icon: IconCheck, type: 'validate' },
-    { label: 'Filter', icon: IconFilter, type: 'filter' },
-    { label: 'Add Delay', icon: IconClock, type: 'delay' },
-    { label: 'Log Data', icon: IconListDetails, type: 'log' },
+    { label: "Transform Data", icon: IconTransform, type: "transform" },
+    // { label: "Validate", icon: IconCheck, type: "validate" }, // TODO implement later
+    { label: "Filter", icon: IconFilter, type: "filter" },
+    { label: "Add Delay", icon: IconClock, type: "delay" },
+    { label: "Log Data", icon: IconListDetails, type: "log" },
   ];
 
   // Event type definitions
   const eventTypes = [
     {
-      label: 'Incoming Request',
+      label: "Incoming Request",
       icon: IconArrowRight,
-      type: 'incomingRequest' as const,
+      type: "incomingRequest" as const,
     },
     {
-      label: 'Response',
+      label: "Response",
       icon: IconCheck,
-      type: 'response' as const,
+      type: "response" as const,
     },
     {
-      label: 'Request Failed',
+      label: "Request Failed",
       icon: IconAlertCircle,
-      type: 'requestFailed' as const,
+      type: "requestFailed" as const,
     },
     {
-      label: 'Timeout',
+      label: "Timeout",
       icon: IconClockHour4,
-      type: 'timeout' as const,
+      type: "timeout" as const,
     },
   ];
 
   // Update pipeline steps
-  const handlePipelineStepsChange = (eventId: string, steps: FlowStep[]) => {
+  const handlePipelineStepsChange = (
+    eventId: string,
+    steps: WeaveFlowStep[]
+  ) => {
     form.setFieldValue(
-      'events',
+      "events",
       form.values.events.map((event) =>
         event.id === eventId
           ? {
@@ -180,41 +188,41 @@ export function FlowEditorClientPage({
 
   // Add block to a specific pipeline
   const handleAddBlock = (eventId: string, type: string) => {
-    let newStep: FlowStep;
+    let newStep: WeaveFlowStep;
     switch (type) {
-      case 'transform':
+      case "transform":
         newStep = {
           id: crypto.randomUUID(),
-          action: { type: 'transformData', expression: '' },
+          action: { type: "transformData", expression: "" },
         };
         break;
-      case 'filter':
+      case "filter":
         newStep = {
           id: crypto.randomUUID(),
-          action: { type: 'filter', expression: '' },
+          action: { type: "filter", expression: "" },
         };
         break;
-      case 'delay':
+      case "delay":
         newStep = {
           id: crypto.randomUUID(),
-          action: { type: 'delay', ms: 1000 },
+          action: { type: "delay", ms: 1000 },
         };
         break;
-      case 'log':
+      case "log":
         newStep = {
           id: crypto.randomUUID(),
-          action: { type: 'log', message: '' },
+          action: { type: "log", message: "" },
         };
         break;
       default:
         newStep = {
           id: crypto.randomUUID(),
-          action: { type: 'updateResponseBody', value: '' },
+          action: { type: "updateResponseBody", value: "" },
         };
     }
 
     form.setFieldValue(
-      'events',
+      "events",
       form.values.events.map((event) =>
         event.id === eventId
           ? {
@@ -235,7 +243,7 @@ export function FlowEditorClientPage({
       handleAddBlock(eventId, selectedBlockType);
       setModalOpened(false);
       setSelectedBlockType(null);
-      setModalStep('block');
+      setModalStep("block");
     }
   };
 
@@ -243,17 +251,17 @@ export function FlowEditorClientPage({
   const handleModalClose = () => {
     setModalOpened(false);
     setSelectedBlockType(null);
-    setModalStep('block');
+    setModalStep("block");
   };
 
   // Handle block type selection
   const handleBlockTypeSelect = (type: string) => {
     setSelectedBlockType(type);
-    setModalStep('pipeline');
+    setModalStep("pipeline");
   };
 
-  const handleAddEvent = (type: Event['type']) => {
-    const newEvent: Event = {
+  const handleAddEvent = (type: WeaveEvent["type"]) => {
+    const newEvent: WeaveEvent = {
       id: Math.random().toString(36).slice(2),
       type,
       name: `${type} ${form.values.events.length + 1}`,
@@ -264,7 +272,7 @@ export function FlowEditorClientPage({
       },
       enabled: true,
     };
-    form.setFieldValue('events', [...form.values.events, newEvent]);
+    form.setFieldValue("events", [...form.values.events, newEvent]);
   };
 
   return (
@@ -292,7 +300,7 @@ export function FlowEditorClientPage({
                               value={event.name}
                               onChange={(e) =>
                                 form.setFieldValue(
-                                  'events',
+                                  "events",
                                   form.values.events.map((ev) =>
                                     ev.id === event.id
                                       ? { ...ev, name: e.currentTarget.value }
@@ -301,14 +309,14 @@ export function FlowEditorClientPage({
                                 )
                               }
                               size="xs"
-                              style={{ width: '200px' }}
+                              style={{ width: "200px" }}
                             />
                             <Switch
                               checked={event.enabled}
-                              label={event.enabled ? 'Active' : 'Inactive'}
+                              label={event.enabled ? "Active" : "Inactive"}
                               onChange={(e) =>
                                 form.setFieldValue(
-                                  'events',
+                                  "events",
                                   form.values.events.map((ev) =>
                                     ev.id === event.id
                                       ? {
@@ -329,11 +337,11 @@ export function FlowEditorClientPage({
                               <Switch
                                 checked={event.pipeline.enabled}
                                 label={
-                                  event.pipeline.enabled ? 'Active' : 'Inactive'
+                                  event.pipeline.enabled ? "Active" : "Inactive"
                                 }
                                 onChange={(e) =>
                                   form.setFieldValue(
-                                    'events',
+                                    "events",
                                     form.values.events.map((ev) =>
                                       ev.id === event.id
                                         ? {
@@ -356,9 +364,9 @@ export function FlowEditorClientPage({
                               handlePipelineStepsChange(event.id, steps)
                             }
                             eventType={
-                              event.type === 'incomingRequest'
-                                ? 'request'
-                                : 'response'
+                              event.type === "incomingRequest"
+                                ? "request"
+                                : "response"
                             }
                           />
                         </Paper>
@@ -376,7 +384,7 @@ export function FlowEditorClientPage({
                   href={`/app/deployments/${deployment.id}`}
                   leftSection={<IconArrowLeft size={16} />}
                 >
-                  {' '}
+                  {" "}
                   Back
                 </Button>
                 <Paper p="md" withBorder>
@@ -444,12 +452,12 @@ export function FlowEditorClientPage({
           opened={modalOpened}
           onClose={handleModalClose}
           title={
-            modalStep === 'block' ? 'Select Block Type' : 'Select Pipeline'
+            modalStep === "block" ? "Select Block Type" : "Select Pipeline"
           }
           size="md"
         >
           <Stack>
-            {modalStep === 'block' ? (
+            {modalStep === "block" ? (
               <>
                 <Text size="sm">Select the type of block to add:</Text>
                 <Stack>
@@ -485,7 +493,7 @@ export function FlowEditorClientPage({
                 <Group justify="flex-end" mt="md">
                   <Button
                     variant="subtle"
-                    onClick={() => setModalStep('block')}
+                    onClick={() => setModalStep("block")}
                   >
                     Back
                   </Button>

--- a/packages/management/src/app/app/deployments/[id]/flow/page.tsx
+++ b/packages/management/src/app/app/deployments/[id]/flow/page.tsx
@@ -1,12 +1,12 @@
-import type { Flow, FlowCreate } from '@genie-nexus/types';
-import { createEntity, getEntityByQuery } from '@lib/api/server-api';
-import { redirect } from 'next/navigation';
-import { getDeployment } from '../page';
-import { FlowEditorClientPage } from './_page';
+import type { WeaveFlow, WeaveFlowCreate } from "@genie-nexus/types";
+import { createEntity, getEntityByQuery } from "@lib/api/server-api";
+import { redirect } from "next/navigation";
+import { getDeployment } from "../page";
+import { FlowEditorClientPage } from "./_page";
 
-async function getOrCreateFlow(deploymentId: string): Promise<Flow> {
-  const flow = await getEntityByQuery<Flow>(
-    'flows',
+async function getOrCreateFlow(deploymentId: string): Promise<WeaveFlow> {
+  const flow = await getEntityByQuery<WeaveFlow>(
+    "weaveflows",
     `deploymentId=${deploymentId}&isDeleted=false`
   );
   if (flow) {
@@ -28,8 +28,8 @@ export async function generateMetadata({
   };
 }
 
-async function createFlow(deploymentId: string): Promise<Flow> {
-  const flow = await createEntity<FlowCreate, Flow>('flows', {
+async function createFlow(deploymentId: string): Promise<WeaveFlow> {
+  const flow = await createEntity<WeaveFlowCreate, WeaveFlow>("weaveflows", {
     deploymentId,
     events: [],
     createdAt: new Date().toISOString(),
@@ -50,7 +50,7 @@ export default async function FlowEditorPage({
     getOrCreateFlow(id),
   ]);
 
-  if (deployment.type !== 'weave') {
+  if (deployment.type !== "weave") {
     redirect(`/app/deployments/${id}`);
   }
 

--- a/packages/management/src/lib/components/molecules/pipeline-blocks-form/index.tsx
+++ b/packages/management/src/lib/components/molecules/pipeline-blocks-form/index.tsx
@@ -13,7 +13,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import type { Action, Condition, FlowStep } from '@genie-nexus/types';
+import type { Action, Condition, WeaveFlowStep } from '@genie-nexus/types';
 import { Button, Code, Group, Paper, Stack, Text } from '@mantine/core';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
 import { useState } from 'react';
@@ -36,8 +36,8 @@ import { SortableBlock } from './sortable-block';
 import { getActionLabel } from './types';
 
 type PipelineBlocksFormProps = {
-  steps: FlowStep[];
-  onChange: (steps: FlowStep[]) => void;
+  steps: WeaveFlowStep[];
+  onChange: (steps: WeaveFlowStep[]) => void;
   eventType: 'request' | 'response';
 };
 
@@ -138,7 +138,7 @@ export function PipelineBlocksForm({
         break;
     }
 
-    const newStep: FlowStep = {
+    const newStep: WeaveFlowStep = {
       id: crypto.randomUUID(),
       action,
     };

--- a/packages/management/src/lib/components/molecules/pipeline-blocks-form/types.ts
+++ b/packages/management/src/lib/components/molecules/pipeline-blocks-form/types.ts
@@ -1,4 +1,4 @@
-import type { Action, Condition, FlowStep } from '@genie-nexus/types';
+import type { Action } from '@genie-nexus/types';
 import {
   IconCheck,
   IconClock,
@@ -6,8 +6,6 @@ import {
   IconListDetails,
   IconTransform,
 } from '@tabler/icons-react';
-
-export type { Action, Condition, FlowStep };
 
 export type BlockType = {
   type: Action['type'];

--- a/packages/router/src/core/db/index.ts
+++ b/packages/router/src/core/db/index.ts
@@ -13,7 +13,7 @@ export {
   getDeploymentRepository,
   getProviderRepository,
   getTenantRepository,
-  getFlowRepository,
+  getWeaveFlowRepository,
 } from '@genie-nexus/database';
 
 export function initialize(

--- a/packages/router/src/modules/deployments/execute.ts
+++ b/packages/router/src/modules/deployments/execute.ts
@@ -1,7 +1,7 @@
 import type { Deployment, Provider } from '@genie-nexus/database';
-import type { RequestContext } from '@genie-nexus/types';
+import type { WeaveRequestContext } from '@genie-nexus/types';
 import { getProviderRepository } from '../../core/db/index.js';
-import { getFlowRepository } from '../../core/db/index.js';
+import { getWeaveFlowRepository } from '../../core/db/index.js';
 import { proxyRequest } from '../../weave-providers/http-proxy/proxy.js';
 import { generateStaticResponse } from '../../weave-providers/static/generate-static-response.js';
 import type { ProviderResponse } from '../../weave-providers/types.js';
@@ -36,14 +36,14 @@ export async function executeForLlm(
 
 export async function executeForHttp(
   deployment: Deployment,
-  request: RequestContext
+  request: WeaveRequestContext
 ): Promise<{
   provider: Provider;
-  transformedRequest: RequestContext;
+  transformedRequest: WeaveRequestContext;
   providerResponse: ProviderResponse;
 }> {
   const providerRepository = await getProviderRepository();
-  const flowRepository = await getFlowRepository();
+  const flowRepository = await getWeaveFlowRepository();
 
   // Get the flow for this deployment
   const flow = await flowRepository.getOneByQuery(
@@ -88,7 +88,7 @@ export async function executeForHttp(
   }
 
   // Create a response context from the provider response
-  const responseContext: RequestContext = {
+  const responseContext: WeaveRequestContext = {
     ...transformedRequest,
     responseHeaders: providerResponse.headers,
     responseBody: providerResponse.body,

--- a/packages/router/src/modules/deployments/flow/evaluate-condition.ts
+++ b/packages/router/src/modules/deployments/flow/evaluate-condition.ts
@@ -1,10 +1,10 @@
 import { logger } from '@genie-nexus/logger';
-import type { Condition, RequestContext } from '@genie-nexus/types';
+import type { Condition, WeaveRequestContext } from '@genie-nexus/types';
 import { getFieldValue } from './get-field-value.js';
 
 export function evaluateCondition(
   condition: Condition,
-  context: RequestContext
+  context: WeaveRequestContext
 ): boolean {
   if (!condition) return true;
 

--- a/packages/router/src/modules/deployments/flow/evaluate-conditions.ts
+++ b/packages/router/src/modules/deployments/flow/evaluate-conditions.ts
@@ -1,10 +1,10 @@
 import { logger } from '@genie-nexus/logger';
-import type { Condition, RequestContext } from '@genie-nexus/types';
+import type { Condition, WeaveRequestContext } from '@genie-nexus/types';
 import { evaluateCondition } from './evaluate-condition.js';
 
 export function evaluateConditions(
   conditions: Condition[],
-  context: RequestContext
+  context: WeaveRequestContext
 ): boolean {
   logger.debug('Evaluating conditions', { conditions, context });
   for (const condition of conditions) {

--- a/packages/router/src/modules/deployments/flow/execute-action.ts
+++ b/packages/router/src/modules/deployments/flow/execute-action.ts
@@ -1,4 +1,4 @@
-import type { Action, RequestContext } from '@genie-nexus/types';
+import type { Action, WeaveRequestContext } from '@genie-nexus/types';
 import { getLogger } from '../../../core/get-logger.js';
 
 // Maximum allowed delay in milliseconds (5 seconds)
@@ -6,7 +6,7 @@ const MAX_DELAY_MS = 5000;
 
 export async function executeAction(
   action: Action,
-  context: RequestContext
+  context: WeaveRequestContext
 ): Promise<void> {
   const logger = getLogger();
 

--- a/packages/router/src/modules/deployments/flow/execute-flow-event.ts
+++ b/packages/router/src/modules/deployments/flow/execute-flow-event.ts
@@ -1,13 +1,13 @@
-import type { Flow, RequestContext } from '@genie-nexus/types';
+import type { WeaveFlow, WeaveRequestContext } from '@genie-nexus/types';
 import { getLogger } from '../../../core/get-logger.js';
 import { evaluateConditions } from './evaluate-conditions.js';
 import { executeAction } from './execute-action.js';
 
 export async function executeFlowEvent(
-  flow: Flow,
+  flow: WeaveFlow,
   eventType: 'incomingRequest' | 'response',
-  context: RequestContext
-): Promise<RequestContext> {
+  context: WeaveRequestContext
+): Promise<WeaveRequestContext> {
   const logger = getLogger();
   logger.debug('Executing flow event', { flowId: flow.id, eventType });
 

--- a/packages/router/src/modules/deployments/flow/get-field-value.ts
+++ b/packages/router/src/modules/deployments/flow/get-field-value.ts
@@ -1,6 +1,9 @@
-import type { RequestContext } from '@genie-nexus/types';
+import type { WeaveRequestContext } from '@genie-nexus/types';
 
-export function getFieldValue(field: string, context: RequestContext): unknown {
+export function getFieldValue(
+  field: string,
+  context: WeaveRequestContext
+): unknown {
   const [section, key] = field.split('.');
   switch (section) {
     case 'request':

--- a/packages/router/src/modules/weave/routes/process-request.ts
+++ b/packages/router/src/modules/weave/routes/process-request.ts
@@ -1,4 +1,4 @@
-import type { RequestContext } from '@genie-nexus/types';
+import type { WeaveRequestContext } from '@genie-nexus/types';
 import type { Request, Response } from 'express';
 import { checkApiKeyInRequest } from '../../api-key/check-api-key-in-request.js';
 import { ApiKeyNotPresentError } from '../../api-key/errors/api-key-not-present-error.js';
@@ -56,11 +56,20 @@ export async function processRequest(
   }
 
   const flattenedPath = Array.isArray(path) ? path.join('/') : (path ?? '');
+
   // Create the request context
-  const requestContext: RequestContext = {
+  const requestContext: WeaveRequestContext = {
     path: !flattenedPath.startsWith('/') ? `/${flattenedPath}` : flattenedPath,
     method: req.method,
-    requestHeaders: req.headers as Record<string, string>,
+    requestHeaders: Object.fromEntries(
+      Object.entries(req.headers).flatMap(([k, v]) =>
+        v === undefined
+          ? []
+          : Array.isArray(v)
+            ? v.map((val) => [k, val])
+            : [[k, v]]
+      )
+    ) as Record<string, string>,
     requestBody: req.body,
     responseHeaders: {},
     responseBody: undefined,

--- a/packages/router/src/weave-providers/http-proxy/proxy.ts
+++ b/packages/router/src/weave-providers/http-proxy/proxy.ts
@@ -1,5 +1,5 @@
 import type { WeaveHttpProxyProvider } from '@genie-nexus/types';
-import type { RequestContext } from '@genie-nexus/types';
+import type { WeaveRequestContext } from '@genie-nexus/types';
 import { getLogger } from '../../core/get-logger.js';
 import { validateUrlDestination } from '../../core/utils/validate-url-destination.js';
 import type { ProviderResponse } from '../types.js';
@@ -8,7 +8,7 @@ export const NOT_ALLOWED_REQUEST_HEADERS = ['host', 'authorization'];
 
 export async function proxyRequest(
   provider: WeaveHttpProxyProvider,
-  request: RequestContext,
+  request: WeaveRequestContext,
   path: string
 ): Promise<ProviderResponse> {
   const logger = getLogger();

--- a/packages/types/src/schemas/flow.ts
+++ b/packages/types/src/schemas/flow.ts
@@ -135,15 +135,15 @@ export const actionSchema = z.discriminatedUnion('type', [
   setProviderActionSchema,
 ]);
 
-export const flowStepSchema = z.object({
+export const weaveFlowStepSchema = z.object({
   id: z.string(),
   conditions: z.array(conditionSchema).optional(),
   action: actionSchema,
 });
 
-export const pipelineSchema = z.object({
+export const weavePipelineSchema = z.object({
   id: z.string(),
-  steps: z.array(flowStepSchema),
+  steps: z.array(weaveFlowStepSchema),
   enabled: z.boolean(),
 });
 
@@ -151,11 +151,11 @@ export const eventSchema = z.object({
   id: z.string(),
   type: z.enum(['incomingRequest', 'response', 'requestFailed', 'timeout']),
   name: z.string(),
-  pipeline: pipelineSchema,
+  pipeline: weavePipelineSchema,
   enabled: z.boolean(),
 });
 
-export const flowSchema = z.object({
+export const weaveFlowSchema = z.object({
   id: z.string(),
   deploymentId: z.string(),
   events: z.array(eventSchema),

--- a/packages/types/src/types/flow.ts
+++ b/packages/types/src/types/flow.ts
@@ -10,13 +10,13 @@ import type {
   equalsConditionSchema,
   eventSchema,
   filterActionSchema,
-  flowSchema,
-  flowStepSchema,
+  weaveFlowSchema,
+  weaveFlowStepSchema,
   isEmptyConditionSchema,
   isNotEmptyConditionSchema,
   logActionSchema,
   notEqualsConditionSchema,
-  pipelineSchema,
+  weavePipelineSchema,
   removeRequestHeaderActionSchema,
   removeResponseHeaderActionSchema,
   setProviderActionSchema,
@@ -68,10 +68,10 @@ export type LogAction = z.infer<typeof logActionSchema>;
 export type SetProviderAction = z.infer<typeof setProviderActionSchema>;
 export type Action = z.infer<typeof actionSchema>;
 
-export type FlowStep = z.infer<typeof flowStepSchema>;
-export type Flow = z.infer<typeof flowSchema>;
+export type WeaveFlowStep = z.infer<typeof weaveFlowStepSchema>;
+export type WeaveFlow = z.infer<typeof weaveFlowSchema>;
 
-export type RequestContext = {
+export type WeaveRequestContext = {
   path: string;
   method: string;
   requestHeaders: Record<string, string>;
@@ -82,7 +82,7 @@ export type RequestContext = {
   providerId: string;
 };
 
-export type Pipeline = z.infer<typeof pipelineSchema>;
-export type Event = z.infer<typeof eventSchema>;
+export type WeavePipeline = z.infer<typeof weavePipelineSchema>;
+export type WeaveEvent = z.infer<typeof eventSchema>;
 
-export type FlowCreate = Omit<Flow, 'id'>;
+export type WeaveFlowCreate = Omit<WeaveFlow, 'id'>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,10 @@ settings:
   excludeLinksFromLockfile: false
   injectWorkspacePackages: true
 
+overrides:
+  brace-expansion@>=1.0.0 <=1.1.11: '>=1.1.12'
+  brace-expansion@>=2.0.0 <=2.0.1: '>=2.0.2'
+
 importers:
 
   .:
@@ -1617,8 +1621,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@3.0.1:
+    resolution: {integrity: sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==}
+    engines: {node: '>= 16'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1633,11 +1638,9 @@ packages:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
-
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@4.0.1:
+    resolution: {integrity: sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==}
+    engines: {node: '>= 18'}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1774,9 +1777,6 @@ packages:
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@9.1.2:
     resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
@@ -5450,7 +5450,7 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@3.0.1: {}
 
   base64-js@1.5.1: {}
 
@@ -5478,14 +5478,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.11:
+  brace-expansion@4.0.1:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.1:
-    dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 3.0.1
 
   braces@3.0.3:
     dependencies:
@@ -5642,8 +5637,6 @@ snapshots:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
-
-  concat-map@0.0.1: {}
 
   concurrently@9.1.2:
     dependencies:
@@ -6958,15 +6951,15 @@ snapshots:
 
   minimatch@10.0.1:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 4.0.1
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 4.0.1
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 4.0.1
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,8 @@
 packages:
   - packages/*
-
+injectWorkspacePackages: true
 onlyBuiltDependencies:
   - sqlite3
-
-injectWorkspacePackages: true
+overrides:
+  brace-expansion@>=1.0.0 <=1.1.11: '>=1.1.12'
+  brace-expansion@>=2.0.0 <=2.0.1: '>=2.0.2'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed all flow-related types, schemas, and API endpoints to use "weave" prefixes (e.g., `Flow` → `WeaveFlow`, `RequestContext` → `WeaveRequestContext`).
  - Updated user interface and API routes to reflect the new "weaveflows" entity.
  - Adjusted type annotations and function signatures throughout the app for consistency with new naming.
- **Chores**
  - Updated pre-commit hook to lint all files instead of staged files.
  - Added dependency overrides to address vulnerabilities in the `brace-expansion` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->